### PR TITLE
Link to OSM Visual History instead of OSM Deep History

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Log of changes since the 1.1.0 version
 
+#### 1.3.1
+
+* Link to OSM Visual History instead of OSM Deep History
+
 #### 1.3.0
 
 * Update mapbox-gl-js to 0.4.3

--- a/lib/map.js
+++ b/lib/map.js
@@ -782,9 +782,10 @@ function displayDiff(id, featureMap) {
           {
             target: '_blank',
             class: 'cmap-hlist-item cmap-pointer cmap-noselect',
-            href: '//osmlab.github.io/osm-deep-history/#/' + type + '/' + id
+            href:
+              '//willemarcel.github.io/osm-visual-history/#/' + type + '/' + id
           },
-          'Deep History'
+          'Visual History'
         )
       )
     )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "changeset-map",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "dist/bundle.js",
   "scripts": {


### PR DESCRIPTION
Example: http://willemarcel.github.io/osm-visual-history/#/way/30772020