### PR TITLE
Add Zoom Navigation Control to the map

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -656,6 +656,12 @@ export class Map {
       dragRotate: false,
       touchZoomRotate: false
     });
+
+    this.map.addControl(
+      new mapboxgl.NavigationControl({ showCompass: false }),
+      'top-right'
+    );
+
     this.map.on('styledata', () => {
       if (!this.baseLayerData) return;
       console.log('style event fired 2');
@@ -667,6 +673,7 @@ export class Map {
       this.addMapLayers();
       cmap.emit('load');
     });
+
     this.map.on('load', () => {
       this.mapLoaded = true;
       if (this.queue.length > 0) {


### PR DESCRIPTION
Zooming on a desktop is not a problem, but on a touch device one is helpless without the NavigationControls which are added here.

Documentation:
Example https://docs.mapbox.com/mapbox-gl-js/example/navigation/
Config https://docs.mapbox.com/mapbox-gl-js/api/#navigationcontrol

---

I could not test this locally. I have the system active now, but the bundle.js is not refreshed on my system, so the changes in this file never showed in my browser. However, its a simple change so I hope it will just work. Please test it before considering a merge.

--- 

This is a step to improve https://github.com/mapbox/osmcha-frontend/issues/341 once it is added to the osmcha-frontend.