### PR TITLE
Change open-feature label to avoid confusion

### DIFF
--- a/lib/featureDiff.js
+++ b/lib/featureDiff.js
@@ -56,7 +56,7 @@ const MetadataTable = function({ featuresWithId, id }) {
           ]}
         />
         <Dropdown
-          display="Open with"
+          display="Open feature"
           options={[
             {
               label: 'JOSM',


### PR DESCRIPTION
<img width="394" alt="open_feature" src="https://user-images.githubusercontent.com/445970/68700757-4e697e80-053a-11ea-8fc5-9eb767c245fe.png">

* Change open-feature label from "Open with" to "Open feature" to avoid
potential confusion with OSMCha "Open with" control used to open a
changeset