### PR TITLE
Make longer tag-keys visible / Update style.css

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -168,9 +168,7 @@
 }
 .cmap-container .cmap-diff-table th {
   width: 80px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
+  overflow-wrap: break-word;
 }
 .cmap-container .cmap-diff-table tbody tr:nth-of-type(even) {
   background: #fff;


### PR DESCRIPTION
Make longer tag-keys visible by removing the css that did hide them.

Example: parking:lane:both and parking:lane:both:parallel where both parking:lane:…
The information was lost and could not be restored without css-hacks.

Before:
<img width="423" alt="Bildschirmfoto 2020-03-04 um 16 41 14" src="https://user-images.githubusercontent.com/111561/75896318-33977e80-5e37-11ea-8a78-6e811fbfb778.png">

After:
<img width="422" alt="Bildschirmfoto 2020-03-04 um 16 41 07" src="https://user-images.githubusercontent.com/111561/75896335-3abe8c80-5e37-11ea-893f-b44c1b9f57b8.png">

Its less nice to look at "after", but it shows all needed information, which is worth the change IMO.