### PR TITLE
target=_blank: add noopener to fix eslint error

### DIFF
--- a/lib/dropdown.js
+++ b/lib/dropdown.js
@@ -64,8 +64,8 @@ class DropdownContent extends React.PureComponent {
             )}
             {i.href ? (
               <a
-                target={'_blank'}
-                rel="noreferrer"
+                target="_blank"
+                rel="noopener noreferrer"
                 href={i.href}
                 onClick={this.props.toggleDropdown}
                 className={`${this.isActive(i) ? 'is-active' : ''}`}

--- a/lib/sidebar.js
+++ b/lib/sidebar.js
@@ -192,7 +192,7 @@ export class Sidebar extends React.PureComponent {
             <li>
               <a
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="cmap-hlist-item cmap-noselect cmap-pointer cmap-c-link-osm"
                 href={'https://openstreetmap.org/changeset/' + changesetId}
               >
@@ -202,7 +202,7 @@ export class Sidebar extends React.PureComponent {
             <li>
               <a
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="cmap-hlist-item cmap-noselect cmap-pointer cmap-c-link-osmcha"
                 href={`${config.osmchaBase}changesets/${changesetId}/`}
               >
@@ -212,7 +212,7 @@ export class Sidebar extends React.PureComponent {
             <li>
               <a
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="cmap-hlist-item cmap-noselect cmap-pointer cmap-c-link-achavi"
                 href={
                   'https://overpass-api.de/achavi/?changeset=' + changesetId
@@ -224,7 +224,7 @@ export class Sidebar extends React.PureComponent {
             <li>
               <a
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="cmap-hlist-item cmap-noselect cmap-pointer cmap-c-link-osmhv"
                 href={
                   'http://osmhv.openstreetmap.de/changeset.jsp?id=' +
@@ -237,7 +237,7 @@ export class Sidebar extends React.PureComponent {
             <li>
               <a
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="cmap-hlist-item cmap-noselect cmap-pointer cmap-c-link-josm"
                 href={
                   'http://127.0.0.1:8111/import?url=http://www.openstreetmap.org/api/0.6/changeset/' +
@@ -251,7 +251,7 @@ export class Sidebar extends React.PureComponent {
             <li>
               <a
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="cmap-hlist-item cmap-noselect cmap-pointer cmap-c-link-id"
                 href={
                   'http://preview.ideditor.com/release#map=15/' +
@@ -280,7 +280,7 @@ export class Sidebar extends React.PureComponent {
             <li>
               <a
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="cmap-hlist-item cmap-noselect cmap-pointer cmap-u-link-osm"
                 href={'https://openstreetmap.org/user/' + userName}
               >
@@ -290,7 +290,7 @@ export class Sidebar extends React.PureComponent {
             <li>
               <a
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="cmap-hlist-item cmap-noselect cmap-pointer cmap-u-link-hdyc"
                 href={'http://hdyc.neis-one.org/?' + userName}
               >
@@ -300,7 +300,7 @@ export class Sidebar extends React.PureComponent {
             <li>
               <a
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="cmap-hlist-item cmap-noselect cmap-pointer cmap-u-link-disc"
                 href={
                   'http://resultmaps.neis-one.org/osm-discussion-comments?uid=' +
@@ -313,7 +313,7 @@ export class Sidebar extends React.PureComponent {
             <li>
               <a
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="cmap-hlist-item cmap-noselect cmap-pointer cmap-u-link-comm"
                 href={
                   'http://resultmaps.neis-one.org/osm-discussion-comments?uid=115894' +


### PR DESCRIPTION
This solves the following ESLint error:

>Using target="_blank" without rel="noopener noreferrer" is a security risk: see https://mathiasbynens.github.io/rel-noopener
> eslint(react/jsx-no-target-blank)