### PR TITLE
Show map also when changeset still open

### DIFF
--- a/lib/getChangeset.js
+++ b/lib/getChangeset.js
@@ -82,9 +82,8 @@ function getDataParam(c) {
   return (
     '[out:xml][adiff:%22' +
     c.from.toString() +
-    ',%22,%22' +
-    c.to.toString() +
-    '%22];(node(bbox)(changed);way(bbox)(changed);relation(bbox)(changed););out%20meta%20geom(bbox);'
+    (c.to ? '%22,%22' + c.to.toString() : '') +
+    '%22];nwr(bbox)(changed);out%20meta%20geom(bbox);'
   );
 }
 


### PR DESCRIPTION
Resolve #240 using the one-timestamp variant of the Overpass `adiff` statement if the `closed_at` property of the changeset is not set. For example
```
[adiff:"2023-10-25T07:00:00Z"]
```

Also, simplify the overpass query using the new-ish [`nwr`](https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL#The_Query_Statement) Overpass statement.